### PR TITLE
Dockerfile and devcontainer setting fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,13 +8,15 @@
 	"dockerFile": "../Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-        "terminal.integrated.shell.linux": null,
-        "python.pythonPath": "/usr/local/bin/python"
+	"settings": {
+		"terminal.integrated.shell.linux": null,
+		"python.pythonPath": "/usr/local/bin/python"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": ["ms-python.python"]
+	"extensions": [
+		"ms-python.python"
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 LABEL author="Jiri Podivin"
 LABEL version="0.1"


### PR DESCRIPTION
Docker now pulls python 3.7 explicitly.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>