### PR TITLE
We only need to build package for one version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Higher versions are overwhelmingly backwards compatible.
So we are just taxing the servers for no reason.
Signed-off-by: Jiri Podivin <jpodivin@gmail.com>