### PR TITLE
Genotype clone method removed

### DIFF
--- a/pystrand/genotypes.py
+++ b/pystrand/genotypes.py
@@ -89,21 +89,10 @@ class Genotype(np.ndarray):
             #Random mask is used if none defined.
             mask = np.ndarray(self.genotype_shape, dtype=bool)
 
-        descendant_genome = self.clone()
+        descendant_genome = self.copy()
         descendant_genome[mask] = partner_genotype[mask]
 
         return descendant_genome
-
-    def clone(self):
-        """
-        Returns copy of this Genome object.
-        Genome, gene values and genome shape are all preserved.
-        """
-
-        return Genotype(
-            self.genotype_shape,
-            gene_vals=self.gene_vals,
-            default_genome=self.copy())
 
     @property
     def genotype_shape(self):

--- a/pystrand/populations.py
+++ b/pystrand/populations.py
@@ -98,7 +98,7 @@ class BasePopulation:
         if strategy == 'clone':
             new_individuals = np.random.choice(self._individuals, size_difference)
             for individual in new_individuals:
-                individual['genotype'] = individual['genotype'].clone()
+                individual['genotype'] = individual['genotype'].copy()
                 individual['genotype'].protected = False
 
         elif strategy == 'random':
@@ -160,7 +160,7 @@ class BasePopulation:
 
         #Ugly but it works.
         return np.array(
-            [(fitness, genotype.clone()) for fitness, genotype in self._individuals[indices]],
+            [(fitness, genotype.copy()) for fitness, genotype in self._individuals[indices]],
             dtype=self._dtype)
 
     def append_individuals(self, new_individuals):

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -37,7 +37,7 @@ class TestPointMutation(unittest.TestCase):
         """
         for genome in self.test_genotypes:
             genome = self.test_genotypes[genome]
-            altered_genome = genome['genotype'].clone()
+            altered_genome = genome['genotype'].copy()
 
             altered_genome.mutate(mut.PointMutation(1.0))
 
@@ -62,7 +62,7 @@ class TestBlockMutation(unittest.TestCase):
         """
         for genome in self.test_genotypes:
             genome = self.test_genotypes[genome]
-            altered_genome = genome['genotype'].clone()
+            altered_genome = genome['genotype'].copy()
 
             altered_genome.mutate(mut.BlockMutation(1.0))
 
@@ -86,7 +86,7 @@ class TestPermutationMutation(unittest.TestCase):
         """
         for genome in self.test_genotypes:
             genome = self.test_genotypes[genome]
-            altered_genome = genome['genotype'].clone()
+            altered_genome = genome['genotype'].copy()
 
             altered_genome.mutate(mut.PermutationMutation(1.0))
 
@@ -110,7 +110,7 @@ class TestShiftMutation(unittest.TestCase):
         """
         for genome in self.test_genotypes:
             genome = self.test_genotypes[genome]
-            altered_genome = genome['genotype'].clone()
+            altered_genome = genome['genotype'].copy()
 
             altered_genome.mutate(mut.ShiftMutation(1.0))
 


### PR DESCRIPTION
Method effectivelly duplicated functionality of
numpy native copy. But didn't provide anything extra.
As such it was removed and calls replaced.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>